### PR TITLE
Make .env Token Setup Cell Cross-Platform Compatible

### DIFF
--- a/demos/data_system/walkthrough.ipynb
+++ b/demos/data_system/walkthrough.ipynb
@@ -51,7 +51,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 2,
+            "execution_count": null,
             "metadata": {
                 "vscode": {
                     "languageId": "shellscript"
@@ -68,13 +68,22 @@
                 }
             ],
             "source": [
-                "%%bash\n",
-                "if ! grep -q '^SDS_SECRET_TOKEN=' .env 2>/dev/null; then\n",
-                "    echo \"SDS_SECRET_TOKEN=\" >> .env\n",
-                "fi\n",
+                "from pathlib import Path\n",
                 "\n",
-                "echo \"Now edit the .env file to set your SDS_SECRET_TOKEN from:\"\n",
-                "echo \"https://sds.crc.nd.edu/users/generate-api-key/.\"\n"
+                "env_file = Path(\".env\")\n",
+                "\n",
+                "if not env_file.exists():\n",
+                "    env_file.write_text(\"\")\n",
+                "\n",
+                "lines = env_file.read_text().splitlines()\n",
+                "\n",
+                "# Check if SDS_SECRET_TOKEN line already exists\n",
+                "if not any(line.startswith(\"SDS_SECRET_TOKEN=\") for line in lines):\n",
+                "    with env_file.open(\"a\") as f:\n",
+                "        f.write(\"\\nSDS_SECRET_TOKEN=\")\n",
+                "\n",
+                "print(\"Now edit the .env file to set your SDS_SECRET_TOKEN from:\")\n",
+                "print(\"https://sds.crc.nd.edu/users/generate-api-key/\")"
             ]
         },
         {


### PR DESCRIPTION
### Summary

This pull request replaces the use of `%%bash` in the Jupyter notebook with a Python-based alternative for setting up the `.env` file. The change ensures cross-platform compatibility, especially for Windows users where `%%bash` and Unix tools like `grep` are not available by default.

---

### Before

```bash
%%bash
if ! grep -q '^SDS_SECRET_TOKEN=' .env 2>/dev/null; then
    echo "SDS_SECRET_TOKEN=" >> .env
fi

echo "Now edit the .env file to set your SDS_SECRET_TOKEN from:"
echo "https://sds.crc.nd.edu/users/generate-api-key/."
```

---

### After

```python
from pathlib import Path

env_file = Path(".env")

if not env_file.exists():
    env_file.write_text("")

lines = env_file.read_text().splitlines()

if not any(line.startswith("SDS_SECRET_TOKEN=") for line in lines):
    with env_file.open("a") as f:
        f.write("\nSDS_SECRET_TOKEN=")

print("Now edit the .env file to set your SDS_SECRET_TOKEN from:")
print("https://sds.crc.nd.edu/users/generate-api-key/")
```

---


Using native Python avoids shell dependency issues and makes the notebook fully usable on Windows systems without extra configuration.
